### PR TITLE
Fix typo in header, remove Firefox warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 
 > A terminal (portfolio) theme for VuePress based on [vue-terminal](https://github.com/jsmith/vue-terminal)!
 
-> WARNING: This package does NOT work with Firefox due to an incompatible Regex :(
-
 ## Demos
 [Basic Demo](https://jsmith.github.io/vuepress-theme-terminal)
 
-## Installatino
+## Installation
 ```
 npm install vuepress-theme-terminal
 ```


### PR DESCRIPTION
This theme works well in Firefox 83.0 (64-bit) on Linux.

I cannot say what versions of Firefox it doesn't work under.

For that reason, perhaps it is too soon to remove this warning.